### PR TITLE
allowed chars from string to char array

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,25 @@
-const ALLOWED_CHARS: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const ALLOWED_CHARS: [char; 62] = [
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+];
 
-fn generate_string(num: i32) -> String {
-    let mut result = String::new(); // Assuming you're generating passwords of length 4
-    let mut num = num;
+fn generate_string(mut num: i32) -> String {
+    let mut result = String::with_capacity(4);
 
     while num >= 0 {
         let index = (num % ALLOWED_CHARS.len() as i32) as usize;
-        result.push(ALLOWED_CHARS.chars().nth(index).unwrap());
+        result.push(ALLOWED_CHARS[index]);
         num = (num / ALLOWED_CHARS.len() as i32) - 1;
     }
 
     result
 }
 
-
 fn brute_force(s: &str) -> bool {
-
-    for i in 0..1_000_000_000 {
+    for i in 0..1_000_000 {
         if generate_string(i) == s {
             return true;
         }
@@ -26,7 +29,8 @@ fn brute_force(s: &str) -> bool {
 
 fn main() {
     const MAX_LENGTH: usize = 4;
-    let password = "aaaa";
+    let password = "9999";
+
     if password.len() > MAX_LENGTH {
         println!("Password should be less than {} symbols", MAX_LENGTH);
     } else {
@@ -34,6 +38,7 @@ fn main() {
         let found = brute_force(password);
         let end = std::time::Instant::now();
         let duration = end - start;
+
         if found {
             println!("Password Found! During: {:?} milliseconds", duration.as_millis());
         } else {


### PR DESCRIPTION
*I switched the allowed chars variable from a **string** variable to an array of **chars** for these reasons:

- An array of chars allows for direct access to individual characters using indexing. This can be more efficient than traversing characters in a string slice, which requires converting to an iterator and navigating through the slice.
- Arrays have a fixed size known at compile time, whereas string slices have a dynamic length. This predictability can enable better optimization by the compiler.
- String slices come with additional metadata and methods for string manipulation. An array of chars eliminates the need for such overhead.